### PR TITLE
fix: allow empty dataFields for rs-api

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -45,9 +45,7 @@ export function validateRSQuery(query) {
         if (!q.id) {
           return new Error('\'id\' field must be present in query object');
         }
-        if (!q.dataField) {
-          return new Error('\'dataField\' field must be present in query object');
-        } if (Object.prototype.toString.call(q.dataField) !== '[object Array]') {
+        if (q.dataField && Object.prototype.toString.call(q.dataField) !== '[object Array]') {
           return new Error('\'dataField\' field must be an array');
         }
       } else {


### PR DESCRIPTION
## What this PR does?
- doesn't throw error, even when dataField is empty for rs-api

## Test
- the query gets fired, even when dataField isn't there
https://www.loom.com/share/fea56f6a21ba42679f3a2e3d4ec7c944